### PR TITLE
ManagePeriods to Production

### DIFF
--- a/blackstone-webapp/src/components/ButtonArrayHeader.vue
+++ b/blackstone-webapp/src/components/ButtonArrayHeader.vue
@@ -11,6 +11,7 @@
                 <span v-if="get_arrow(b) == 's'">&larr;</span>
                 <span v-else-if="get_arrow(b) == 'd'">&Larr;</span>
                 <span v-else-if="get_arrow(b) == 'b'">&larrb;</span>
+                <span v-else-if="get_arrow(b) == 'h'">&#8962;</span>
             </b-button>
 
             <div style="display: inline-block;"><slot></slot></div>
@@ -24,6 +25,7 @@
                 <span v-if="get_arrow(b) == 's'">&rarr;</span>
                 <span v-else-if="get_arrow(b) == 'd'">&Rarr;</span>
                 <span v-else-if="get_arrow(b) == 'b'">&rarrb;</span>
+                <span v-else-if="get_arrow(b) == 'h'">&#8962;</span>
             </b-button>
         </div>
         <div style="clear:both;"></div>

--- a/blackstone-webapp/src/components/HoursDisplay.vue
+++ b/blackstone-webapp/src/components/HoursDisplay.vue
@@ -1,0 +1,106 @@
+
+<template>
+	<div class="hours-display">
+		<p class="hours-num">
+			<!-- This is all on one line to prevent spaces before the decimal point... -->
+			<span class="hours-whole">{{whole_component}}</span><span class="hours-decimal" v-show="!decimal_NaN">.{{decimal_component}}</span>
+		</p>
+		<p class="hours-name"> {{title}} </p>
+	</div>
+</template>
+
+<script>
+
+export default {
+	name: 'hours-display',
+	props: {
+
+		// The name to display
+		title: String,
+
+		// The value to display
+		value: Number,
+
+		// The size of the text/div
+		size: {
+			type: String,
+			default: "12"
+		},
+
+		// The number of decimal places to round to
+		decimalPlaces: {
+			type: Number,
+			default: 2,
+		}
+	},
+
+	methods: {
+		
+	},
+
+	computed: {
+
+		// Get the part before the decimal point, defaulting to 0 if there is none
+		whole_component: function() {
+			let hours = this.formatted_hours;
+			let whole = hours.substring(0, hours.indexOf('.'));
+
+			return (whole == "") ? "0" : whole;
+		},
+
+		// Get the part after the decimal point, defaulting to the appropriate number of 0s if there is none
+		decimal_component: function() {
+			let hours = this.formatted_hours;
+			let decimal = hours.substring(hours.indexOf('.') + 1);
+
+			return (decimal == "") ? get_0s : decimal;
+		},
+
+		// Check whether the decimal component is NaN
+		decimal_NaN: function() {
+			return this.decimal_component == "NaN";
+		},
+
+		get_0s: function() {
+			return "0".repeat(this.decimalPlaces);
+		},
+
+		// Source: https://stackoverflow.com/questions/6134039/format-number-to-always-show-2-decimal-places
+		formatted_hours: function() {
+			return Number(Math.round(parseFloat(this.value + 'e' + this.decimalPlaces)) + "e-" + this.decimalPlaces).toFixed(this.decimalPlaces);
+		},
+	},
+}
+</script>
+
+<style scoped>
+
+	/* The div element containing each hours field (number + name) */
+	.hours-display {
+		display: inline-block;
+		text-align: center;
+		padding: 0px 15px;
+	}
+
+	/* The div element containing the entire hour number */
+	.hours-num {
+		font-weight: bold;
+		font-family: "Courier New", Courier, monospace;
+		margin: 0px;
+	}
+
+	/* The whole part of the hour number (before the decimal place) */
+	.hours-whole {
+		font-size: 175%;
+	}
+
+	/* The decimal part of the hour number (after the decimal place) */
+	.hours-decimal {
+		font-size: 1.2em;
+	}
+
+	/* The name labelling the hour number */
+	.hours-name {
+
+	}
+</style>

--- a/blackstone-webapp/src/components/ModalDRS.vue
+++ b/blackstone-webapp/src/components/ModalDRS.vue
@@ -57,7 +57,7 @@
 			<h3>Success!</h3>
 		</b-modal>
 
-		<b-modal v-model="failure_modal_visible" ok-only ok-variant="outline-danger">
+		<b-modal v-model="failure_modal_visible" ok-only ok-variant="outline-danger" no-close-on-backdrop no-close-on-esc hide-header-close>
 			<template slot="modal-title">
 				<slot name="failureModalHeader"><h4>Save Failed</h4></slot>
 			</template>

--- a/blackstone-webapp/src/components/ModalDRS.vue
+++ b/blackstone-webapp/src/components/ModalDRS.vue
@@ -62,6 +62,18 @@
 				<slot name="failureModalHeader"><h4>Save Failed</h4></slot>
 			</template>
 			<slot name="failureModalBody">Something went wrong updating the database.</slot>
+			<div slot="modal-footer">
+				<div style="float: left">
+					<slot name="failureModalFooter"></slot>
+				</div>
+				<span>&nbsp;</span>
+				<div style="float: right">
+					<b-button
+						variant="outline-danger"
+						@click="failure_modal_visible = false"
+					>OK</b-button>
+				</div>
+			</div>
 		</b-modal>
 	</div>
 </template>

--- a/blackstone-webapp/src/components/ModalDRS.vue
+++ b/blackstone-webapp/src/components/ModalDRS.vue
@@ -1,33 +1,17 @@
 <template>
-	<div class="save_bar">
+	<div class="modal_drs">
 
-		<div ref="bottom_bar" class="bottom-bar" v-show="show_bar">
-			<b-button
-				:variant="discard_variant"
-				:disabled="disableIfNoChanges && !has_any_changes"
-				@click="discard"
-				class="change_button"
-			>
-				Discard Changes
-			</b-button>
-			<b-button
-				v-if="!hideReset"
-				:variant="reset_variant"
-				:disabled="disableIfNoChanges && !has_any_changes"
-				@click="reset"
-				class="change_button"
-			>
-				Reset Changes
-			</b-button>
-			<b-button
-				:variant="save_variant"
-				:disabled="disableIfNoChanges && !has_saveable_changes"
-				@click="save"
-				class="change_button"
-			>
-				Save Changes
-			</b-button>
-		</div>
+		<DiscardResetSave v-show="show_buttons"
+			:hasChanges="hasChanges"
+			:hasUnsaveableChanges="hasUnsaveableChanges"
+			:hideReset="hideReset"
+			:disableIfNoChanges="disableIfNoChanges"
+			:saveVariant="saveVariant"
+			:resetVariant="resetVariant"
+			:discardVariant="discardVariant"
+			@save="save" @reset="reset" @discard="discard"
+		>
+		</DiscardResetSave>
 
 		<b-modal size="lg" v-model="modal_visible" hide-footer lazy>
 			<template slot="modal-header">
@@ -84,9 +68,10 @@
  
 <script>
 import {Status} from "@/scripts/Status.js";
+import DiscardResetSave from '@/components/DiscardResetSave';
 
 export default {
-	name: 'save_bar',
+	name: 'modal_drs',
 	props: {
 		hasChanges: Boolean,
 		hasUnsaveableChanges: Boolean,
@@ -94,12 +79,12 @@ export default {
 			default: false,
 		},
 
-		// Whether to display the bar at the bottom of the screen
+		// Whether to display the buttons
 		show: {
 			default: true,
 		},
 
-		// If set, display the bar iff there are changes
+		// If set, display the buttons iff there are changes
 		showIfChanges: {
 			default: false,
 		},
@@ -119,6 +104,7 @@ export default {
 		// 	default: () => {},
 		// },
 	},
+	components: {DiscardResetSave},
 
 	data: function() {
 		return {
@@ -132,27 +118,6 @@ export default {
 	},
 
 	computed: {
-		save_variant: function() {
-			if (this.saveVariant != undefined) {
-				return this.saveVariant;
-			}
-			return this.has_saveable_changes ? "success" : "outline-success";
-		},
-
-		reset_variant: function() {
-			if (this.resetVariant != undefined) {
-				return this.resetVariant;
-			}
-			return this.has_any_changes ? "warning" : "outline-warning";
-		},
-
-		discard_variant: function() {
-			if (this.discardVariant != undefined) {
-				return this.discardVariant;
-			}
-			return this.has_any_changes ? "danger" : "outline-danger";
-		},
-
 		has_saveable_changes: function() {
 			return this.hasChanges;
 		},
@@ -165,7 +130,7 @@ export default {
 			return this.showIfChanges === "" || this.showIfChanges == true;
 		},
 
-		show_bar: function() {
+		show_buttons: function() {
 			return this.show_if_changes ? this.has_any_changes : this.show;
 		}
 	},
@@ -263,16 +228,6 @@ export default {
 </script>
  
 <style scoped>
-	.bottom-bar {
-		background-color: #333;
-		overflow: hidden;
-		position: fixed;
-		bottom: 0;
-		width: 100%;
-		padding: 10px;
-		z-index: 10;
-	}
-
 	.change_button {
 		margin: 0px 5px;
 	}

--- a/blackstone-webapp/src/components/PeriodsClassesDisplay.vue
+++ b/blackstone-webapp/src/components/PeriodsClassesDisplay.vue
@@ -29,7 +29,7 @@
                     <td>
                         <b-dropdown right id="dropdown-text" class="m-2"
                             :variant="dropdown_variant"
-                            :text="get_class(display)"
+                            :text="get_class_str(display)"
                             style="min-width: 100%;"
                             :disabled="display.length == 0"
                         >
@@ -71,7 +71,7 @@
                 >
                     <span v-if="is_future_period(s, year)"></span>
                     <span v-else-if="is_active(s, year)">
-                        &#9745; {{get_class(s,year)}}
+                        &#9745; {{get_class_str(s,year)}}
                     </span>
                     <span v-else>&#9744;</span>
                 </td>
@@ -164,7 +164,11 @@ export default {
                 return "- n/a -  ";
             }
             var period = Period.makePeriod(season, year);
-            var temp = this.active_periods[period.toString()];
+            return this.active_periods[period.toString()];
+        },
+
+        get_class_str: function(season, year) {
+            var temp = this.get_class(season, year);
             return (temp != null) ? temp : "Not Active";
         },
 

--- a/blackstone-webapp/src/components/PeriodsClassesDisplay.vue
+++ b/blackstone-webapp/src/components/PeriodsClassesDisplay.vue
@@ -66,7 +66,7 @@
                 <td v-for="s in seasons"
                     @mouseover="hover_cell(s, year)"
                     @click="select_cell(s, year)"
-                    style="cursor:pointer; text-align: left;"
+                    style="text-align: left;"
                     :class="get_cell_classes(s, year)"
                 >
                     <span v-if="is_future_period(s, year)"></span>
@@ -236,21 +236,24 @@ export default {
     table.table th.table-hov, table.table td.table-hov {
       background-color: #DFDFDF;
       /*background-color: #BBB;*/
+      cursor: pointer;
     }
 
     table.table th.table-sel, table.table td.table-sel {
       background-color: #CBE0FE;
       /*background-color: #9ABCEA;*/
+      cursor: pointer;
     }
 
     table.table th.table-hov-sel, table.table td.table-hov-sel {
       background-color: #B2C4DE;
       /*background-color: #769BCC;*/
+      cursor: pointer;
     }
 
     table.table td.table-unavailable {
         background-color: #c0c0c0;
-        cursor: pointer;
+        cursor: default;
     }
 
     table.table thead tr th.main_header {

--- a/blackstone-webapp/src/components/PeriodsClassesDisplay.vue
+++ b/blackstone-webapp/src/components/PeriodsClassesDisplay.vue
@@ -11,21 +11,26 @@
         <br />
 
         <div v-if="detail_view != undefined">
+            <br />
             <table style="width: 95%; margin: auto; text-align:left;">
                 <tr>
                     <td style="width:5%;">{{ is_active(cur_period) ? "&#9745;" : "&#9744;" }}</td>
-                    <td style="width:47%;">Active in current quarter ({{cur_period}})</td>
-                    <td style="width:48%; text-align:center;">
+                    <td style="width:45%;">Active in current quarter ({{cur_period}})</td>
+                    <td style="width:5%;">{{ is_active(reg_period) ? "&#9745;" : "&#9744;" }}</td>
+                    <td style="width:45%;">Registered for next quarter ({{reg_period}})</td>
+                </tr>
+            </table>
+            <br />
+            </table>
+            <table style="width: 95%; margin: auto; text-align:left;">
+                <tr>
+                    <td style="width:35%; text-align:center;">
                         <span v-if="display.length == 0 || is_future_period(display)">
-                            <i>Choose a period below.</i>
+                            <i style="color: #999">Choose a period in the table below.</i>
                         </span>
                         <span v-else-if="is_active(display)">Youth's class in {{display}}:</span>
                         <span v-else><i>Youth was not active.</i></span>
                     </td>
-                </tr>
-                <tr>
-                    <td>{{ is_active(reg_period) ? "&#9745;" : "&#9744;" }}</td>
-                    <td>Registered for next quarter ({{reg_period}})</td>
                     <td>
                         <b-dropdown right id="dropdown-text" class="m-2"
                             :variant="dropdown_variant"
@@ -37,11 +42,14 @@
                                 <i>Change the status and class for {{youth_name}} in {{display}}.</i>
                             </b-dropdown-text>
                             <b-dropdown-divider></b-dropdown-divider>
-                            <b-dropdown-group id="add-class" header="Classes" style="width: 240px;">
+                            <b-dropdown-group id="add-class" header="Set Class" style="width: 240px;">
                                 <b-dropdown-item-button v-for="c in class_list" @click="set_class(display, c)">{{c}}</b-dropdown-item-button>
                             </b-dropdown-group>
                             <b-dropdown-divider></b-dropdown-divider>
-                            <b-dropdown-item-button @click="set_class(display, null)">-none-</b-dropdown-item-button>
+                            <b-dropdown-group id="rem-class" header="Remove Class" style="width: 240px;">
+                                <b-dropdown-item-button @click="set_class(display, 'Unknown')">Unknown</b-dropdown-item-button>
+                                <b-dropdown-item-button @click="set_class(display, null)">-none-</b-dropdown-item-button>
+                            </b-dropdown-group>
                         </b-dropdown>
                     </td>
                 </tr>

--- a/blackstone-webapp/src/components/PeriodsClassesDisplay.vue
+++ b/blackstone-webapp/src/components/PeriodsClassesDisplay.vue
@@ -24,7 +24,7 @@
             </table>
             <table style="width: 95%; margin: auto; text-align:left;">
                 <tr>
-                    <td style="width:35%; text-align:center;">
+                    <td style="width:45%; text-align:center;">
                         <span v-if="display.length == 0 || is_future_period(display)">
                             <i style="color: #999">Choose a period in the table below.</i>
                         </span>

--- a/blackstone-webapp/src/components/ProfileFieldDisplay.vue
+++ b/blackstone-webapp/src/components/ProfileFieldDisplay.vue
@@ -3,18 +3,6 @@
 
     {{ value_string }}
 
-      <!-- Display each item in an array -->
-      <!-- <div v-if="type === 'Array'">
-        <div v-for="item in get_original_value()" class="field_list_element">
-          {{ item }}
-        </div>
-      </div> -->
-
-      <!-- Display the string version of the value -->
-      <!-- <div v-else>
-        {{ get_string() }}
-      </div> -->
-
   </div>
 </template>
 
@@ -54,12 +42,6 @@ export default {
         //   let num = val + "";
         //   num += "__________".substring(num.length);
         //   return `(${num.substring(0,3)}) ${num.substring(3,6)}-${num.substring(6,10)}`;
-
-        // Display an array as a list with commas
-        case "Array":
-          let arr = "";
-          val.forEach(item => arr += item + ", ");
-          return arr;
 
         // Display a time in 12h format (as opposed to 24h)
         case "Time":

--- a/blackstone-webapp/src/components/ProfileFields.vue
+++ b/blackstone-webapp/src/components/ProfileFields.vue
@@ -567,7 +567,7 @@ export default {
 
     warning_msg: function(field) {
       if (this.blank_required_fields.includes(field)) {
-        return "Required fields cannot be blank.";
+        return "This field is required, but no value was found.";
       }
       else if (this.unremoved_temp_fields.includes(field)) {
         return "This is a non-standard field.";

--- a/blackstone-webapp/src/components/ProfileFields.vue
+++ b/blackstone-webapp/src/components/ProfileFields.vue
@@ -219,7 +219,6 @@ import HoursDisplay from '@/components/HoursDisplay';
 import SpecialInputReset from '@/components/SpecialInputReset';
 import ProfileFieldDisplay from '@/components/ProfileFieldDisplay';
 import PeriodsClassesDisplay from '@/components/PeriodsClassesDisplay';
-import SaveBar from '@/components/SaveBar';
 import DiscardResetSave from '@/components/DiscardResetSave';
 
 export default {
@@ -231,7 +230,6 @@ export default {
     SpecialInputReset,
     ProfileFieldDisplay,
     PeriodsClassesDisplay,
-    SaveBar,
     DiscardResetSave,
   },
 

--- a/blackstone-webapp/src/components/ProfileFields.vue
+++ b/blackstone-webapp/src/components/ProfileFields.vue
@@ -9,13 +9,7 @@
     <br />
 
     <div ref="stats_div" v-show="profile!=null" style="margin:auto;">
-      <div class="hours_div" v-for="item in hour_fields">
-        <p class="hours_num">
-          <span class="hours_whole">{{item.Whole!=""? item.Whole : "0"}}</span>
-          <span class="hours_decimal" v-show="item.Decimal != 'NaN'">.{{item.Decimal}}</span>
-        </p>
-        <p class="hours_name"> {{item.Name}} </p>
-      </div>
+      <HoursDisplay v-for="item in hour_fields" v-bind="item" />
     </div>
 
     <br />
@@ -216,9 +210,12 @@ import {db} from '@/firebase';
 import {firebase} from '@/firebase';
 import firebase_app from 'firebase/app';
 import firebase_auth from 'firebase/auth';
+
 import {Status} from '@/scripts/Status.js';
 import {forKeyVal} from '@/scripts/ParseDB.js';
+
 import ToggleButton from '@/components/ToggleButton';
+import HoursDisplay from '@/components/HoursDisplay';
 import SpecialInputReset from '@/components/SpecialInputReset';
 import ProfileFieldDisplay from '@/components/ProfileFieldDisplay';
 import PeriodsClassesDisplay from '@/components/PeriodsClassesDisplay';
@@ -230,6 +227,7 @@ export default {
   props: ["profile", "headerDoc", "periodData", "edit", "showOptionalFields", "hideFields", "hideWarnings"],
   components: {
     ToggleButton,
+    HoursDisplay,
     SpecialInputReset,
     ProfileFieldDisplay,
     PeriodsClassesDisplay,
@@ -265,7 +263,6 @@ export default {
         "Class",
       ],
 
-      hour_fields_list: ["Hours Earned", "Hours Spent", "Pending Hours"],
       temp_fields: [],
 
       row_status: null,
@@ -378,17 +375,20 @@ export default {
     },
 
     hour_fields: function() {
-      let temp = [];
 
-      this.hour_fields_list.forEach(title => {
-        let hours = this.format_hours(title, 2);
-        temp.push({
-          Name:    title,
-          Whole:   hours.substring(0,hours.indexOf('.')),
-          Decimal: hours.substring(hours.indexOf('.')+1),
-        });
-      });
-      return temp;
+      // If local values hasn't been set yet, give an empty list
+      if (this.local_values == null) return [];
+
+      // Compute the spendable balance: earned - spent
+      let balance = this.local_values["Hours Earned"] - this.local_values["Hours Spent"];
+
+      // Return the list of objects
+      return [
+        {title: "Hours Earned",  value: this.local_values["Hours Earned"]},
+        {title: "Hours Spent",   value: this.local_values["Hours Spent"]},
+        {title: "Pending Hours", value: this.local_values["Pending Hours"]},
+        {title: "Spendable Balance", value: balance},
+      ];
     },
 
     youth_name: function() {
@@ -550,13 +550,6 @@ export default {
         // TODO: This might have to be more sophisticated for different data types
         return field != "";
       };
-    },
-
-    // Source: https://stackoverflow.com/questions/6134039/format-number-to-always-show-2-decimal-places
-    format_hours: function(field, dp) {
-      if (this.local_values == null) return "";
-      let hours = this.local_values[field];
-      return Number(Math.round(parseFloat(hours + 'e' + dp)) + "e-" + dp).toFixed(dp);
     },
 
     // Set the status of a given field in the Status object and make appropriate changes
@@ -838,35 +831,6 @@ export default {
 
   .changed_title {
     font-weight: bold;
-  }
-
-  /* The div element containing each hours field (number + name) */
-  .hours_div {
-    display: inline-block;
-    text-align: center;
-    padding: 0px 15px;
-  }
-
-  /* The div element containing the entire hour number */
-  .hours_num {
-    font-weight: bold;
-    font-family: "Courier New", Courier, monospace;
-    margin: 0px;
-  }
-
-  /* The whole part of the hour number (before the decimal place) */
-  .hours_whole {
-    font-size: 175%;
-  }
-
-  /* The decimal part of the hour number (after the decimal place) */
-  .hours_decimal {
-    font-size: 1.2em;
-  }
-
-  /* The name labelling the hour number */
-  .hours_name {
-
   }
 
   .section_name {

--- a/blackstone-webapp/src/components/ProfileFields.vue
+++ b/blackstone-webapp/src/components/ProfileFields.vue
@@ -13,15 +13,6 @@
     </div>
 
     <br />
-
-    <PeriodsClassesDisplay
-      :active_periods="active_periods"
-      :seasons="season_list"
-      v-bind="periodData"
-      disable_selection
-      style="max-width: 95%; margin:auto"
-    />
-
     <br />
 
     <table id="fields_table" ref="fields_table" v-show="profile!=null" class="table table-bordered" style="max-width: 95%">
@@ -219,7 +210,7 @@ import DiscardResetSave from '@/components/DiscardResetSave';
 
 export default {
   name: 'profile_fields',
-  props: ["profile", "headerDoc", "periodData", "edit", "showOptionalFields", "hideFields", "disableWarnings", "hideTitle"],
+  props: ["profile", "headerDoc", "edit", "showOptionalFields", "hideFields", "disableWarnings", "hideTitle"],
   components: {
     ToggleButton,
     HoursDisplay,
@@ -408,11 +399,6 @@ export default {
 
     has_changes_strict: function() {
       return this.check_edits(true);
-    },
-
-    season_list: function() {
-      if (this.periodData == null) return undefined;
-      return this.periodData.seasons;
     },
 
     change_modal_cell_type_old: function() {

--- a/blackstone-webapp/src/components/ProfileFields.vue
+++ b/blackstone-webapp/src/components/ProfileFields.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="profile_fields">
 
-    <div ref="name_div" v-show="profile!=null">
+    <div ref="name_div" v-show="profile!=null && hideTitle!=true">
       <div class="full_name">{{youth_name}}</div>
       <div class="id_parens">(ID: {{youth_id}})</div>
     </div>
@@ -219,7 +219,7 @@ import DiscardResetSave from '@/components/DiscardResetSave';
 
 export default {
   name: 'profile_fields',
-  props: ["profile", "headerDoc", "periodData", "edit", "showOptionalFields", "hideFields", "disableWarnings"],
+  props: ["profile", "headerDoc", "periodData", "edit", "showOptionalFields", "hideFields", "disableWarnings", "hideTitle"],
   components: {
     ToggleButton,
     HoursDisplay,
@@ -806,6 +806,7 @@ export default {
   .full_name {
     font-size: 2em;
     margin-bottom: 0;
+    color: black;
   }
 
   .id_parens {

--- a/blackstone-webapp/src/components/ProfileFields.vue
+++ b/blackstone-webapp/src/components/ProfileFields.vue
@@ -31,11 +31,7 @@
         <tr v-for="field in section.Data" v-show="show_container(field)">
           <td style="width: 35%">
             {{field}}{{field_types[field] === "Boolean" ? "?" : ""}}
-            <b-badge
-              v-show="hideWarnings == undefined && needs_warning(field)"
-              pill variant="warning" class="warning_icon"
-              v-b-tooltip.hover.html="warning_msg(field)"
-            >!</b-badge>
+            <b-badge v-show="needs_warning(field) && disableWarnings != true" pill variant="warning" class="warning_icon" v-b-tooltip.hover.html="warning_msg(field)">!</b-badge>
           </td>
           <td style="width: 65%">
             <ProfileFieldDisplay v-model="local_values[field]" :type="field_types[field]"></ProfileFieldDisplay>
@@ -223,7 +219,7 @@ import DiscardResetSave from '@/components/DiscardResetSave';
 
 export default {
   name: 'profile_fields',
-  props: ["profile", "headerDoc", "periodData", "edit", "showOptionalFields", "hideFields", "hideWarnings"],
+  props: ["profile", "headerDoc", "periodData", "edit", "showOptionalFields", "hideFields", "disableWarnings"],
   components: {
     ToggleButton,
     HoursDisplay,

--- a/blackstone-webapp/src/components/ProfileItemLogs.vue
+++ b/blackstone-webapp/src/components/ProfileItemLogs.vue
@@ -9,6 +9,7 @@
       :groupByOptions="periods"
       :progressiveLoad="true"
       :doc_formatter="work_doc_formatter"
+      :args="extra_args"
       :visible="visible"
       style="width:90%;margin:auto;"
     ></CollectionTable>
@@ -23,6 +24,7 @@
       groupBy="Period"
       :groupByOptions="periods"
       :progressiveLoad="true"
+      :args="extra_args"
       :visible="visible"
       style="width:90%;margin:auto;"
     ></CollectionTable>
@@ -37,6 +39,7 @@
       groupBy="Period"
       :groupByOptions="periods"
       :progressiveLoad="true"
+      :args="extra_args"
       :visible="visible"
       style="width:90%;margin:auto;"
     ></CollectionTable>
@@ -51,6 +54,7 @@ import CollectionTable from "@/components/CollectionTable.vue"
 import {filter} from "@/scripts/Search.js";
 import {make_range_editor} from "@/scripts/Search.js"
 import {custom_filter_editor} from "@/scripts/Search.js"
+import {get_as_date} from "@/scripts/ParseDB.js"
 
 const moment = require("moment");
 var Tabulator = require("tabulator-tables");
@@ -167,6 +171,16 @@ export default {
           "Period": data["Period"],
         };
       },
+
+
+      // Other Tabulator arguments for the tables
+      extra_args: {
+
+        // On load, sort all items from most recent to least recent
+        initialSort: [
+          {column: "Date", dir: "desc"},
+        ],
+      },
     };
   },
 
@@ -212,7 +226,7 @@ export default {
 
     format_date_time: function(cell) {
       var val = cell.getValue();
-      var date = this.get_as_date(val);
+      var date = get_as_date(val);
 
       var day     = this.get_date(date);
       var weekday = this.get_weekday(date);
@@ -231,8 +245,8 @@ export default {
       var val = cell.getValue();
 
       if (Array.isArray(val)) {
-        let date1 = this.get_as_date(val[0]);
-        let date2 = this.get_as_date(val[1]);
+        let date1 = get_as_date(val[0]);
+        let date2 = get_as_date(val[1]);
 
         if (this.same_day(date1, date2)) {
           day     = this.get_date(date1);
@@ -246,7 +260,7 @@ export default {
       }
 
       else {
-        let date = this.get_as_date(val);
+        let date = get_as_date(val);
         day     = this.get_date(date);
         weekday = this.get_weekday(date);
       }
@@ -256,7 +270,7 @@ export default {
 
     format_time: function(cell) {
       var val = cell.getValue();
-      var date = this.get_as_date(val);
+      var date = get_as_date(val);
 
       var time = date.toLocaleTimeString(undefined, {
         hour: "numeric",
@@ -280,7 +294,7 @@ export default {
     date_filter: function(filters, option) {
 
       var datestamp = Array.isArray(option) ? option[0] : option;
-      var date = this.get_as_date(datestamp);
+      var date = get_as_date(datestamp);
 
       // Result will be true if every filter passes
       var result = filters.every(filter => {
@@ -461,7 +475,7 @@ export default {
     time_range_filter: function(search_range, option) {
 
       // Interpret the current cell's value
-      var val = this.get_as_date(option);
+      var val = get_as_date(option);
       var hour = val.getHours().toString();
       var mins = val.getMinutes().toString();
       var time = [hour, mins];
@@ -508,14 +522,23 @@ export default {
     // =-= Sorters =-=-=
 
     date_sorter: function(a, b, aRow, bRow, column, dir, sorterParams) {
-      let a_date = (Array.isArray(a)) ? this.get_as_date(a[0]) : this.get_as_date(a);
-      let b_date = (Array.isArray(b)) ? this.get_as_date(b[0]) : this.get_as_date(b);
+      let a_date = (Array.isArray(a)) ? get_as_date(a[0]) : get_as_date(a);
+      let b_date = (Array.isArray(b)) ? get_as_date(b[0]) : get_as_date(b);
       return a_date.getTime() - b_date.getTime();
     },
 
     time_sorter: function(a, b, aRow, bRow, column, dir, sorterParams) {
-      let sec_diff = a.seconds - b.seconds
-      return sec_diff ? sec_diff : (a.nanoseconds - b.nanoseconds);
+
+      // Get both as dates
+      let a_date = get_as_date(a);
+      let b_date = get_as_date(b);
+
+      // Get differences in hours, minutes, and seconds
+      let h_diff = a_date.getHours() - b_date.getHours();
+      let m_diff = a_date.getMinutes() - b_date.getMinutes();
+      let s_diff = a_date.getSeconds() - b_date.getSeconds();
+
+      return h_diff ? h_diff : (m_diff ? m_diff : s_diff);
     },
 
     hour_sorter: function(a, b, aRow, bRow, column, dir, sorterParams) {
@@ -584,14 +607,6 @@ export default {
       return Object.keys(hours).reduce((a,c) => hours[c] == null ? a : (a + hours[c]), 0);
     },
 
-
-    // Error checking to get a Date object from the database
-    // Should be a Timestamp, but handles error in case it isn't
-    get_as_date: function(date_obj) {
-      return (date_obj.toDate == undefined)
-        ? new Date(date_obj.seconds * 1000)
-        : date_obj.toDate();
-    }
   }
 }
 </script>

--- a/blackstone-webapp/src/components/ProfileItemLogs.vue
+++ b/blackstone-webapp/src/components/ProfileItemLogs.vue
@@ -66,6 +66,13 @@ export default {
     CollectionTable,
   },
 
+  mounted: async function() {
+    var hour_categories_doc = await db.collection("GlobalVariables").doc("Hour Logging Categories").get();
+
+    var data = hour_categories_doc.data();
+    this.hour_categories = data["Categories"];
+  },
+
   data: function() {
     return {
       work_log_collection: null,
@@ -152,25 +159,7 @@ export default {
         },
       ],
 
-      // Helper function to group document data for the work log table
-      work_doc_formatter: (doc) => {
-        var data = doc.data();
-        return {
-          "Date": [ data["Check In"], data["Check Out"] ],
-          "Check In": data["Check In"],
-          "Check Out": data["Check Out"],
-          "Hours": {
-            "Class": data["Class"],
-            "Elective": data["Elective"],
-            "Bike Riding or Cycling": data["Bike Riding or Cycling"],
-            "Shop Support": data["Shop Support"],
-            "Other": data["Other"],
-            "Misc": data["Misc"],
-          },
-          "Notes": data["Notes"],
-          "Period": data["Period"],
-        };
-      },
+      hour_categories: [],
 
 
       // Other Tabulator arguments for the tables
@@ -182,6 +171,24 @@ export default {
         ],
       },
     };
+  },
+
+  computed: {
+
+    // Helper function to group document data for the work log table
+    work_doc_formatter: function() {
+      return (doc) => {
+        var data = doc.data();
+        return {
+          "Date": [ data["Check In"], data["Check Out"] ],
+          "Check In": data["Check In"],
+          "Check Out": data["Check Out"],
+          "Hours": this.make_hours_obj(data),
+          "Notes": data["Notes"],
+          "Period": data["Period"],
+        };
+      };
+    },
   },
 
   watch: {
@@ -202,6 +209,15 @@ export default {
   },
 
   methods: {
+
+    make_hours_obj: function(data) {
+      var obj = {};
+      for (let i in this.hour_categories) {
+        let category = this.hour_categories[i];
+        obj[category] = data[category];
+      };
+      return obj;
+    },
 
     // =-= Formatters =-=-=
 

--- a/blackstone-webapp/src/components/ProfilePopup.vue
+++ b/blackstone-webapp/src/components/ProfilePopup.vue
@@ -1,0 +1,175 @@
+
+<template>
+	<div class="hours-display">
+		<b-button
+			@click="show_popup"
+			style="margin-bottom: 1rem"
+			:variant="variant"
+			:disabled="ID == null"
+		>
+			View Profile
+		</b-button>
+
+		<b-modal v-model="modal_visible" hide-footer lazy>
+			<template slot="modal-title">
+				<div class="full_name">{{youth_name}}</div>
+      			<div class="id_parens">(ID: {{youth_id}})</div>
+			</template>
+			<div ref="body_fields" v-show="current_profile != null">
+				<ProfileFields
+					:profile="current_profile"
+					:headerDoc="current_headers"
+					:disableWarnings="true"
+					:hideTitle="true"
+				/>
+			</div>
+		</b-modal>
+	</div>
+</template>
+
+<script>
+// @ is an alias to /src
+
+// Firebase
+import {db} from '@/firebase';
+
+// Components
+import ProfileFields from "@/components/ProfileFields.vue"
+
+export default {
+	name: 'hours-display',
+	components: {
+		ProfileFields,
+	},
+
+	props: {
+
+		// The ID of the youth to display
+		ID: String,
+
+		// The variant for the button to display the popup
+		variant: {
+			type: String,
+			default: "info",
+		},
+
+
+		// Allow certain pieces from the database to be passed in as arguments
+		// rather than loaded from the database directly.
+
+		// If load... is set to false, will not load this item from the database
+		// Otherwise, If nothing is passed in, will retrieve from the database
+
+		// The youth profile to display
+		loadProfile: {
+			type: Boolean,
+			default: true,
+		},
+		profile: {
+			type: Object,
+			default: null,
+		},
+
+		// The list of profile field headers and their data type
+		// A document with the headers for the fields
+		loadHeaders: {
+			type: Boolean,
+			default: true,
+		},
+		headers: {
+			type: Object,
+			default: null,
+		},
+	},
+
+	data: function() {
+		return {
+			// profile_db: db.collection("GlobalYouthProfile"),
+			// periods_db: db.collection("GlobalPeriods"),
+
+			modal_visible: false,
+
+			loaded_profile: null,
+			loaded_headers: null,
+		};
+	},
+
+	mounted: async function() {},
+
+	methods: {
+
+		// Display the Profile popup
+		show_popup: async function() {
+
+			// Make sure we have everything we need from the database
+			await this.ensure_data_loaded();
+
+			// Display the modal
+			this.modal_visible = true;
+		},
+
+
+		// Ensure all required data has been loaded fromthe database, if applicable
+		ensure_data_loaded: async function() {
+			// Load profile, if requested
+	    	if (this.loadProfile == true && this.profile == null) {
+				await this.get_profile();
+			}
+
+			// Load headers, if requested
+			if (this.loadHeaders == true && this.headers == null) {
+				await this.get_headers();
+			}
+		},
+
+		// Grab the youth profile from Firebase
+		async get_profile() {
+			let snapshot = db.collection("GlobalYouthProfile").doc(this.ID);
+			this.loaded_profile = await snapshot.get();
+		},
+
+		// Grab the header document from Firebase
+		async get_headers() {
+			this.loaded_headers = await db
+				.collection("GlobalFieldsCollection")
+				.doc("Youth Profile")
+				.get()
+		},
+	},
+
+	computed: {
+		youth_name: function() {
+			return "Yves Shum";
+		},
+
+		youth_id: function() {
+			return "10001";
+		},
+
+		// Two conditions - loadProfile bool value, profile set or not set
+		// Should only load from db if it's okay to load it and no data passed from parent
+		current_profile: function() {
+			if (this.loadProfile == true && this.profile == null) {
+				return this.loaded_profile;
+			}
+			else {
+				return this.profile;
+			}
+		},
+
+		// Two conditions - loadHeaders bool value, headers set or not set
+		// Should only load from db if it's okay to load it and no data passed from parent
+		current_headers: function() {
+			if (this.loadHeaders == true && this.headers == null) {
+				return this.loaded_headers;
+			}
+			else {
+				return this.headers;
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+</style>

--- a/blackstone-webapp/src/components/ProfilePopup.vue
+++ b/blackstone-webapp/src/components/ProfilePopup.vue
@@ -139,11 +139,17 @@ export default {
 
 	computed: {
 		youth_name: function() {
-			return "Yves Shum";
+			if (this.current_profile == null) {
+				return "";
+			} else {
+				let first_name = this.current_profile.data()["First Name"]
+				let last_name  = this.current_profile.data()["Last Name"];
+				return `${first_name} ${last_name}`;
+			}
 		},
 
 		youth_id: function() {
-			return "10001";
+			return this.ID;
 		},
 
 		// Two conditions - loadProfile bool value, profile set or not set

--- a/blackstone-webapp/src/components/ProfilePopup.vue
+++ b/blackstone-webapp/src/components/ProfilePopup.vue
@@ -3,7 +3,6 @@
 	<div class="profile-popup">
 		<b-button
 			@click="show_popup"
-			style="margin-bottom: 1rem"
 			:variant="variant"
 			:disabled="ID == null"
 		>

--- a/blackstone-webapp/src/components/ProfilePopup.vue
+++ b/blackstone-webapp/src/components/ProfilePopup.vue
@@ -1,6 +1,6 @@
 
 <template>
-	<div class="hours-display">
+	<div class="profile-popup">
 		<b-button
 			@click="show_popup"
 			style="margin-bottom: 1rem"
@@ -37,7 +37,7 @@ import {db} from '@/firebase';
 import ProfileFields from "@/components/ProfileFields.vue"
 
 export default {
-	name: 'hours-display',
+	name: 'profile-popup',
 	components: {
 		ProfileFields,
 	},

--- a/blackstone-webapp/src/components/YouthIDSelector.vue
+++ b/blackstone-webapp/src/components/YouthIDSelector.vue
@@ -143,7 +143,7 @@ Emits:
             },
             remove: {
                 type: Array,
-                default: [],
+                default: () => [],
             },
         },
         data () {

--- a/blackstone-webapp/src/components/YouthIDSelector.vue
+++ b/blackstone-webapp/src/components/YouthIDSelector.vue
@@ -141,6 +141,10 @@ Emits:
                 type: Object,
                 default: () => {},
             },
+            remove: {
+                type: Array,
+                default: [],
+            },
         },
         data () {
             return {
@@ -220,6 +224,9 @@ Emits:
                 var options;
                 var displays = new Object();
 
+                var options_to_use =
+                    this.options.filter(youth => !Youth.contains(this.remove, youth))
+
                 // Special case: If the search term is blank, match everything
                 // Note that the search function can handle this too, but in this case
                 // it's easier to just do this all at once
@@ -228,7 +235,7 @@ Emits:
 
                     // Create the unmarked displays for each option, and return all options
                     // Since there is no search, the Display fields will all be singleton arrays where the one element is an unmarked segment representing the whole string.
-                    this.options.forEach(opt => {
+                    options_to_use.forEach(opt => {
                         let temp = {};
                         Object.keys(opt).forEach(key => {
                             temp[key] = [{seg: opt[key], mark: false}];
@@ -236,10 +243,10 @@ Emits:
                         displays[opt["ID"]] = temp;
                     });
 
-                    options = this.options.sort(this.sort_options());
+                    options = options_to_use.sort(this.sort_options());
                 }
 
-                options = this.options.filter(option => {
+                options = options_to_use.filter(option => {
                     var valid = search(this.search_term, option, {
                         fields: Youth.requiredVals(),
                         remove_overlap: true,
@@ -529,6 +536,14 @@ Emits:
             periods: async function() {
                 this.options = await this.getData();
                 this.$emit("ready", this.options);
+            },
+
+            remove: function() {
+                console.log("this.remove", this.remove);
+                if (Youth.contains(this.remove, this.value)) {
+                    console.log("should reset to null");
+                    this.value = null;
+                };
             },
         },
 

--- a/blackstone-webapp/src/scripts/ParseDB.js
+++ b/blackstone-webapp/src/scripts/ParseDB.js
@@ -96,3 +96,172 @@ export function mapKeyVal(arr, op) {
 	// Return the result array
 	return result;
 };
+
+
+/* Maps a one- or two-input function onto the key/value pairs of an Object.
+
+	For example, the following call:
+
+		mapObj( {a: 1, b: 2, c: 3}, (key, val) => {return {key: key + "2", value: val * 2}} )
+
+	...will return the following:
+
+		{a2: 2, b2: 4, c2: 6}
+
+	Single-argument functions should return the new value for that key.
+
+	Two-argument functions should return an object with the fields "key" and "value".
+	If a two argument function returns undefined, that key will be deleted from the object.
+
+*/
+export function mapObj(object, f) {
+  Object.keys(object).forEach(key => {
+
+	// For a single argument function, just apply f to each value
+	if (f.length == 1) {
+		object[key] = f(object[key])
+	}
+
+	// For a double argument function, delete the field on an undefined value,
+	// otherwise set the returned key to the returned value and remove the old
+	// key if it's been changed
+	else {
+
+		// Obtain the mapped value by applying the given function
+		let new_obj = f(key, object[key]);
+
+		// If the function returns undefined, delete the key/value
+		if (new_obj === undefined) {
+			delete object[key];
+		}
+
+		// If not, update the value
+		else {
+			// Delete the old field if applicable
+			if (new_obj.key !== key) {
+				delete object[key];
+			}
+
+			// Add/set the new field
+			object[new_obj.key] = new_obj.value;
+		}
+	}
+  });
+}
+
+
+// Error checking to get a Date object from the database
+// Should be a Timestamp, but handles error in case it isn't
+export function get_as_date(date_obj) {
+  return (date_obj.toDate == undefined)
+	? new Date(date_obj.seconds * 1000)
+	: date_obj.toDate();
+};
+
+
+
+
+
+
+
+export class AwaitTransactions {
+
+	// Initialize the object with reference to a given database
+	constructor(database) {
+
+		// Save the given database
+		this.db = database;
+
+		// Initialize all lists to empty
+		this.transactionList = [];
+		this.nameList = [];
+		this.resultList = [];
+		this.errList = [];
+
+		// Initialize the return function to be undefined
+		this.returnFunc = undefined;
+	}
+
+
+	// Create a new transaction and return its unique index
+	createTransaction (name, transaction) {
+
+		// Add the new transaction to the list
+		this.transactionList.push(transaction);
+		this.nameList.push(name);
+
+		// Add null values to the results and error lists
+		this.resultList.push(null);
+		this.errList.push(null);
+	}
+
+
+	runTransactions () {
+
+		// Don't try and run if the return function is not defined
+		if (this.returnFunc == undefined) {
+			console.error("This AwaitTransactions object cannot be run until it has a return function.")
+			return undefined;
+		}
+
+		// If there are no transactions yet, send a warning but keep going - nothing will happen
+		if (this.numTransactions == 0) {
+			console.warn("No transactions have been created yet.");
+		}
+
+		// Cycle through each transaction
+		this.transactionList.forEach((transaction, n) => {
+
+			// Run the transaction with respect to the specified database
+			this.db.runTransaction(transaction)
+
+			// If the transaction succeeds, set it appropriately
+			.then(result => {
+			  this.resultList[n] = true;
+			  this.checkForCompletion();
+			})
+
+			// Run this if the transaction fails
+			.catch(err => {
+			  this.resultList[n] = false;
+			  this.errList[n] = err;
+			  this.checkForCompletion();
+			});
+		});
+	}
+
+	// Gets the number of transactions
+	numTransactions () {
+		return this.transactionList.length();
+	}
+
+	// Pass a function to handle the results once all transactions have been received
+	setReturnFunc (func) {
+		if (func == null) {
+			console.warn("Passing a null/undefined object as the return function.");
+		}
+		this.returnFunc = func;
+	}
+
+	// If all transactions have come back, run the returnFunc
+	checkForCompletion () {
+
+		// If there are no results yet, quit
+		if (this.resultList.length == 0) return;
+
+		// If there are any null values, quit
+		for (let i in this.resultList) {
+		  if (this.resultList[i] == null) return;
+		}
+
+		// Collect the errors and attach their names
+		let errors = this.errList
+			.map((err, n) => {
+				return (err == null) ? null : {err, name: this.nameList[n]};
+			})
+			.filter(x => x != null);
+
+		// Run the return function on the failed items
+		this.returnFunc(errors);
+	}
+}

--- a/blackstone-webapp/src/scripts/Youth.js
+++ b/blackstone-webapp/src/scripts/Youth.js
@@ -113,7 +113,7 @@ export class Youth {
 	static concat_overwrite(list, new_youth) {
 		new_youth.forEach(youth => {
 			if (Youth.contains(list, youth)) {
-				Youth.replace_in_array(list, youth);
+				list = Youth.replace_in_array(list, youth);
 			}
 			else {
 				list.push(youth);

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -232,6 +232,7 @@ import ProfilePopup from "@/components/ProfilePopup";
 import {Status} from '@/scripts/Status.js';
 import {filter} from "@/scripts/Search.js";
 import {forKeyVal} from '@/scripts/ParseDB.js';
+import {AwaitTransactions} from '@/scripts/ParseDB.js';
 import {Period} from '@/scripts/Period.js';
 import {Youth} from  '@/scripts/Youth.js';
 
@@ -315,10 +316,6 @@ export default {
         {name: 'Current', arr: 'd'},
         {name: 'Registration', arr: 'b', val: 'max'},
       ],
-
-      // Array to store the results of updating the database
-      // TODO: Does this need to exist at the data level? Could be local to the function
-      update_results: [],
 
     };
   },
@@ -710,7 +707,8 @@ export default {
 
     save_changes: async function(accept_func) {
 
-      // Construct the changes for the period object
+      // --- Construct the changes for the period object -----
+
       // Want an object where each key is a year, and each entry is object with fields for each season that needs to change
       // Each season field in turn is a list of youth
       let period_obj = {};
@@ -739,107 +737,63 @@ export default {
       let youth_id_list = Object.keys(this.changes);
       let year_list = Object.keys(period_obj);
 
-      // Initialize the update results
-      this.update_results = {youth: [], years: []};
-      for (var i = 0; i < youth_id_list.length; i++) {
-        this.update_results.youth.push(null);
-      }
-      for (var i = 0; i < year_list.length; i++) {
-        this.update_results.years.push(null);
-      }
 
-      // Update the database for each youth_id
-      // TODO: Is there a way to specify a change to be made to an array without .get() ing it?
-      for (let i = 0; i < youth_id_list.length; i++) {
+      // --- Update the GlobalPeriods list -----
 
-        // Grab the data from the database
-        let youth_id = youth_id_list[i];
-        let youth_db = db.collection("GlobalYouthProfile").doc(youth_id);
-        let youth_doc = await youth_db.get();
-        let youth_data = youth_doc.data();
+      // Add all transactions to this object, which will then run them all at once
+      // and wait for the results to come back before moving on
+      var year_transactions = new AwaitTransactions(db);
 
-        // Initialize a new active_periods array which will be changed
-        let new_active_periods = youth_data["ActivePeriods"];
+      // Loop through each year that needs to be updated
+      Object.keys(period_obj).forEach(year => {
+        let current_doc = this.periods_db.doc(year);
 
-        // Make the changes to the grabbed array
-        Object.keys(this.changes[youth_id].periods).forEach(period => {
-          new_active_periods[period] = this.changes[youth_id].periods[period].new_class;
+        // Create a transaction object to update the document for that year
+        year_transactions.createTransaction(year, t => {
+
+          // Grab the relevant document from the database
+          return t.get(current_doc).then(doc => {
+
+            // Init object to store new state of the database
+            let update_obj = {};
+            let year_data = period_obj[year]
+
+            // Loop through each season that needs an update
+            Object.keys(year_data).forEach(season => {
+
+              // Grab the data from the database
+              // Using let binding so this is a new object for each loop
+              let data = doc.data()[season];
+
+              // Update the database's data with the new entries for each youth,
+              // and save the updated entries to the update object
+              update_obj[season] = Youth.concat_overwrite(data, year_data[season]);
+            });
+
+            // Apply the updates
+            t.update(current_doc, update_obj);
+          });
         });
-
-        // Send the changes back to the database
-        youth_db.update({ActivePeriods: new_active_periods}).then((error) => {
-          if (error) {
-            this.$set(this.update_results.youth, i, this.changes[youth_id]);
-          }
-          else {
-            this.$set(this.update_results.youth, i, true);
-          }
-          check_for_completion(this.update_results);
-        });
-      }
-
-      for (let i = 0; i < year_list.length; i++) {
-
-        // Grab the data from the database
-        let year = year_list[i];
-        let period_db = db.collection("GlobalPeriods").doc(year);
-        let period_doc = await period_db.get();
-        let period_data = period_doc.data();
-
-        // Initialize object to store all db changes for the current year
-        let periods_to_update = {};
-
-        // Take the current database data for each period and add the new youth profiles, overwriting them when they exist already
-        Object.keys(period_obj[year]).forEach(period => {
-          periods_to_update[period] = Youth.concat_overwrite(period_data[period], period_obj[year][period]);
-        });
-
-        period_db.update(periods_to_update).then(error => {
-          if (error) {
-            this.$set(this.update_results.years, i, period_obj[year]);
-          }
-          else {
-            this.$set(this.update_results.years, i, true);
-          }
-          check_for_completion(this.update_results);
-        });
-      }
+      });
 
 
+      // Create a function to handle the transactions when all are completed
       // This runs at the end of each callback to the database
       // Waits until all the changes have returned, then does something with the results
       // If everything succeeded, results will be an array of "true"
       // Any update that failed will be the object that we were trying to update
-      function check_for_completion(results_object) {
-
-        let results = results_object.youth.concat(results_object.years);
-
-        // If there are no results yet, quit
-        if (results.length == 0) return;
-
-        // If there are any null values, quit
-        for (let i in results) {
-          if (results[i] == null) return;
-        }
-
-        // Filter out failed updates - object value rather than "true"
-        let failures = results.filter(x => x != true);
-
-        // If any of the updates failed, show that to the user
-        if (failures.length > 0) {
+      year_transactions.setReturnFunc(errs => {
+        if (errs.length > 0) {
           accept_func(false);
         }
-
-        // If not, give the success modal
         else {
           accept_func(true);
         }
-      }
-    },
+      });
 
-    reset_changes: function(accept_func) {
-      this.changes = new Object();
-      accept_func();
+
+      // Run the accumulated transactions and wait for all to return
+      year_transactions.runTransactions();
     },
 
     discard_changes: function(accept_func) {

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -181,7 +181,14 @@
                   <td v-if="change.youth != undefined" :rowspan="youth_num_changes(change.youth)">
                     {{change.youth["Full Name"]}} ({{change.youth["ID"]}})
                   </td>
-                  <td>{{change.period}}</td>
+                  <td style="position:relative;">
+                    {{change.period}}
+                    <b-badge v-if="!change.old_class"
+                      pill variant="warning"
+                      style="position:absolute; right:.5em; bottom:1.25em;"
+                      v-b-tooltip.hover.html="warning_msg"
+                    >!</b-badge>
+                  </td>
                   <td>{{change.old_class ? change.old_class : "- n/a -"}}</td>
                   <td>{{change.new_class ? change.new_class : "- n/a -"}}</td>
                 </tr>
@@ -353,6 +360,8 @@ export default {
 
       transaction_errors: [],
       show_advanced_errors: false,
+
+      warning_msg: "This change would manually set this youth's class in the current registration period, bypassing the parent registration process. Please be sure this is intended.",
     };
   },
 

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -34,7 +34,13 @@
       <div class="col-right">
         <div v-if="selected_youths.length == 0">
           <h3>Youth Information</h3>
-          Select a single youth to view/edit their classes individually, or select multiple youth with <span style="font-family: Courier, Monaco, monospace;">CTRL</span>-click to perform batch operations.
+          <br />
+          <p style="font-style: italic;">
+            Select a single youth from the table to view/edit their classes individually, or hold <span class="keyboard_button_text">Ctrl</span> or <span class="keyboard_button_text">Shift</span> when clicking to select multiple youth and perform batch operations.
+          </p>
+          <p style="font-style: italic;">
+            In addition, youth from all periods can be found in the selector below the table.
+          </p>
         </div>
 
         <!-- TODO: Load the youth's profile to get their active_periods -->
@@ -952,6 +958,11 @@ export default {
   .id_parens {
     color: gray;
     font-size: 0.75em;
+  }
+
+  .keyboard_button_text {
+    font-family: Courier, Monaco, monospace;
+    padding: 0px .25rem;
   }
 
   .col-container:after {

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -882,4 +882,8 @@ export default {
   }
 
 }
+
+  .changed {
+    font-weight: bold;
+  }
 </style>

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -31,18 +31,6 @@
       </div>
 
       <div class="col-right">
-        <b-modal v-model="viewProfileModalVisible" hide-footer lazy>
-      <div ref="body_fields" v-show="currentProfile != null">
-        <ProfileFields
-          :profile="currentProfile"
-          :headerDoc="header_doc"
-          :periodData="profile_period_data"
-          hideWarnings
-        />
-        <br />
-        <br />
-      </div>
-    </b-modal>
         <div v-if="selected_youths.length == 0">
           <h3>Youth Information</h3>
           Select a single youth to view/edit their classes individually, or select multiple youth with <span style="font-family: Courier, Monaco, monospace;">CTRL</span>-click to perform batch operations.
@@ -66,11 +54,8 @@
               &times;
             </b-button>
           </PeriodsClassesDisplay>
-          <b-button
-            @click="viewProfile"
-            style="margin-bottom: 1rem"
-            variant="info"
-          >View Profile</b-button>
+
+          <ProfilePopup :ID="selected_youth.ID" />
         </div>
 
         <div v-else>
@@ -243,6 +228,7 @@ import ButtonArrayHeader from '@/components/ButtonArrayHeader';
 import SaveBar from '@/components/SaveBar';
 import ProfileFields from "@/components/ProfileFields.vue"
 import ApronBar from "@/components/ApronBar.vue"
+import ProfilePopup from "@/components/ProfilePopup";
 import {Status} from '@/scripts/Status.js';
 import {filter} from "@/scripts/Search.js";
 import {forKeyVal} from '@/scripts/ParseDB.js';
@@ -259,7 +245,8 @@ export default {
     ButtonArrayHeader,
     SaveBar,
     ProfileFields,
-    ApronBar
+    ApronBar,
+    ProfilePopup,
   },
 
   data: function() {
@@ -341,8 +328,6 @@ export default {
     await this.load_metadata();
     await this.load_periods();
     this.switch_to("Current");
-    await this.getHeaders();
-    this.header_doc = await db.collection("GlobalFieldsCollection").doc("Youth Profile").get();
 
     this.period_status = new Object();
 
@@ -884,41 +869,6 @@ export default {
       }
       return cell.getValue();
     },
-
- async viewProfile() {
-      let ID = this.selected_youth.ID;
-      let snapshot = db.collection("GlobalYouthProfile").doc(ID);
-      this.currentProfile = await snapshot.get();
-      this.viewProfileModalVisible = true;
-
-      // window.alert("This is an upcoming feature :) look forward to it!")
-    },
-      async getHeaders() {
-      let headers = await db
-        .collection("GlobalFieldsCollection")
-        .doc("Checked In")
-        .get();
-      headers = headers.data().fields;
-      let fields = [];
-      for (let i = 0; i < headers.length; i++) {
-        fields.push({ key: Object.keys(headers[i])[0], sortable: true });
-      }
-      this.fields = fields;
-    },
-   load_profile_data: async function() {
-        this.profile_periods_doc = await this.periods_db.doc("metadata").get();
-        var data = this.periods_doc.data();
-
-        await Period.setSeasons(data["Seasons"]);
-        this.profile_periods = Period.enumerateStr(data["CurrentPeriod"], data["FirstPeriod"]);
-
-        this.profile_period_data = {
-          cur_period: data["CurrentPeriod"],
-          reg_period: data["CurrentRegistrationPeriod"],
-          seasons:    data["Seasons"],
-          class_list: mapKeyVal(data["Classes"], (name, desc) => name),
-        };
-      },
   }
 
 }

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -20,14 +20,15 @@
           :table_data="display_youths"
           :args="args"
           @deselectedRow="deselected_row"
-          @replaceData="replaceData"
+          @replaceData="reselect_rows"
           @rowClick="row_click"
         />
 
-        <!-- <YouthIDSelector periods="all"
-          :args="{multiple: true, hideSelected: true, closeOnSelect: false, openDirection: 'top'}"
-          @selected="s => selected_bar = s"
-        /> -->
+        <YouthIDSelector periods="all"
+          :args="{hideSelected: true, closeOnSelect: false, openDirection: 'top'}"
+          :remove="selected_youths"
+          @selected="handle_selector"
+        />
       </div>
 
       <div class="col-right">
@@ -309,8 +310,6 @@ export default {
         selectable: true,
       },
 
-      selected_cur: [],
-      selected_bar: [],
       selected_youths: [],
       all_youth: null,
       viewProfileModalVisible: false,
@@ -667,7 +666,7 @@ export default {
 
     // Event handler for tabulator replaceData event
     // Reselects all youth which are currently being edited
-    replaceData: function(data) {
+    reselect_rows: function(data) {
 
       // Get the table
       let table = this.$refs.current_table.tabulator;
@@ -690,6 +689,21 @@ export default {
 
       // Add everyone currently selected in the table to the list
       selected.forEach(r => this.add_to_selected(r.getData()));
+    },
+
+    // Event handler for YouthIDSelector selection
+    // Adds the selected youth to the list
+    handle_selector: function(selection) {
+
+      // Ignore null selection
+      if (selection == null) return;
+
+      // Add Full Name as a field
+      selection["Full Name"] = Youth.getFullName(selection);
+
+      // Add youth from YouthIDSelector to selection and update table to match
+      this.add_to_selected(selection);
+      this.reselect_rows();
     },
 
 

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -148,68 +148,68 @@
         </table>
 
         </div>
+
+        <ModalDRS
+          showIfChanges :hideReset="true"
+          :hasChanges="has_changes"
+          @save="save_changes"
+          @discard="discard_changes"
+        >
+          <template slot="bodyFooter">
+            <table class="table table-bordered">
+              <thead>
+                <tr>
+                  <th scope="col">Name & ID</th>
+                  <th scope="col">Period</th>
+                  <th scope="col">Old Class</th>
+                  <th scope="col">New Class</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="change in change_array" style="padding-top: 0px;">
+                  <td v-if="change.youth != undefined" :rowspan="youth_num_changes(change.youth)">
+                    {{change.youth["Full Name"]}} ({{change.youth["ID"]}})
+                  </td>
+                  <td>{{change.period}}</td>
+                  <td>{{change.old_class ? change.old_class : "- n/a -"}}</td>
+                  <td>{{change.new_class ? change.new_class : "- n/a -"}}</td>
+                </tr>
+              </tbody>
+            </table>
+          </template>
+
+          <template slot="failureModalBody">
+            Something went wrong updating the database. The following changes could not be saved:
+            <br />
+
+            <h4 style="color: black;">Unsaved Youth Profiles</h4>
+            <table class="table table-bordered">
+              <thead>
+                <tr>
+                  <th scope="col">Name & ID</th>
+                  <th scope="col">Period</th>
+                  <th scope="col">Old Class</th>
+                  <th scope="col">New Class</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="change in error_array_youth" style="padding-top: 0px;">
+                  <td v-if="change.youth != undefined" :rowspan="youth_num_changes(change.youth)">
+                    {{change.youth["Full Name"]}} ({{change.youth["ID"]}})
+                  </td>
+                  <td>{{change.period}}</td>
+                  <td>{{change.old_class ? change.old_class : "- n/a -"}}</td>
+                  <td>{{change.new_class ? change.new_class : "- n/a -"}}</td>
+                </tr>
+              </tbody>
+            </table>
+
+            Please take note of these and try again.
+          </template>
+        </ModalDRS>
+
       </div>
     </div>
-
-    <SaveBar
-      showIfChanges
-      :hasChanges="has_changes"
-      @save="save_changes"
-      @reset="reset_changes"
-      @discard="discard_changes"
-    >
-      <template slot="bodyFooter">
-        <table class="table table-bordered">
-          <thead>
-            <tr>
-              <th scope="col">Name & ID</th>
-              <th scope="col">Period</th>
-              <th scope="col">Old Class</th>
-              <th scope="col">New Class</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="change in change_array" style="padding-top: 0px;">
-              <td v-if="change.youth != undefined" :rowspan="youth_num_changes(change.youth)">
-                {{change.youth["Full Name"]}} ({{change.youth["ID"]}})
-              </td>
-              <td>{{change.period}}</td>
-              <td>{{change.old_class ? change.old_class : "- n/a -"}}</td>
-              <td>{{change.new_class ? change.new_class : "- n/a -"}}</td>
-            </tr>
-          </tbody>
-        </table>
-      </template>
-
-      <template slot="failureModalBody">
-        Something went wrong updating the database. The following changes could not be saved:
-        <br />
-
-        <h4 style="color: black;">Unsaved Youth Profiles</h4>
-        <table class="table table-bordered">
-          <thead>
-            <tr>
-              <th scope="col">Name & ID</th>
-              <th scope="col">Period</th>
-              <th scope="col">Old Class</th>
-              <th scope="col">New Class</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="change in error_array_youth" style="padding-top: 0px;">
-              <td v-if="change.youth != undefined" :rowspan="youth_num_changes(change.youth)">
-                {{change.youth["Full Name"]}} ({{change.youth["ID"]}})
-              </td>
-              <td>{{change.period}}</td>
-              <td>{{change.old_class ? change.old_class : "- n/a -"}}</td>
-              <td>{{change.new_class ? change.new_class : "- n/a -"}}</td>
-            </tr>
-          </tbody>
-        </table>
-
-        Please take note of these and try again.
-      </template>
-    </SaveBar>
   </div>
 </template>
 
@@ -225,7 +225,7 @@ import Table from '@/components/Table';
 import PeriodsClassesDisplay from '@/components/PeriodsClassesDisplay';
 import YouthIDSelector from '@/components/YouthIDSelector';
 import ButtonArrayHeader from '@/components/ButtonArrayHeader';
-import SaveBar from '@/components/SaveBar';
+import ModalDRS from '@/components/ModalDRS';
 import ProfileFields from "@/components/ProfileFields.vue"
 import ApronBar from "@/components/ApronBar.vue"
 import ProfilePopup from "@/components/ProfilePopup";
@@ -243,7 +243,7 @@ export default {
     PeriodsClassesDisplay,
     YouthIDSelector,
     ButtonArrayHeader,
-    SaveBar,
+    ModalDRS,
     ProfileFields,
     ApronBar,
     ProfilePopup,

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -803,6 +803,9 @@ export default {
               // Using let binding so this is a new object for each loop
               let data = doc.data()[season];
 
+              // If an array for this period doesn't already exist, create it now
+              if (data == null) data = [];
+
               // Update the database's data with the new entries for each youth,
               // and save the updated entries to the update object
               update_obj[season] = Youth.concat_overwrite(data, year_data[season]);

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -216,10 +216,14 @@
 
 <script>
 // @ is an alias to /src
+
+// Firebase
 import {db} from '../../firebase';
 import {firebase} from '../../firebase';
 import firebase_app from 'firebase/app';
 import firebase_auth from 'firebase/auth';
+
+// Components
 import TopBar from '@/components/TopBar';
 import Table from '@/components/Table';
 import PeriodsClassesDisplay from '@/components/PeriodsClassesDisplay';
@@ -229,6 +233,8 @@ import ModalDRS from '@/components/ModalDRS';
 import ProfileFields from "@/components/ProfileFields.vue"
 import ApronBar from "@/components/ApronBar.vue"
 import ProfilePopup from "@/components/ProfilePopup";
+
+// Scripts
 import {Status} from '@/scripts/Status.js';
 import {filter} from "@/scripts/Search.js";
 import {forKeyVal} from '@/scripts/ParseDB.js';

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -10,6 +10,7 @@
           :left="button_header_l" :right="button_header_r" :current="display_period"
           :min="fst_period" :max="reg_period" :compareFunc="compare_periods"
           @clicked="switch_to"
+          v-show="display_period != null"
         >
           <h3>{{display_period}}{{display_period == cur_period ? " (Current)" : display_period == reg_period ? " (Registration)" : ""}}</h3>
         </ButtonArrayHeader>

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -528,7 +528,7 @@ export default {
       for (let i = 0; i < this.year_list.length; i++) {
         let year = this.year_list[i];
         let snapshot = await this.periods_db.doc(year).get();
-        this.periods[year] = snapshot.data();
+        this.$set(this.periods, year, snapshot.data());
       }
     },
 
@@ -862,7 +862,7 @@ export default {
       // Waits until all the changes have returned, then does something with the results
       // If everything succeeded, results will be an array of "true"
       // Any update that failed will be the object that we were trying to update
-      year_transactions.setReturnFunc(errs => {
+      year_transactions.setReturnFunc(async errs => {
         if (errs.length > 0) {
 
           // Add the intended changes to each error object
@@ -878,6 +878,14 @@ export default {
         else {
           accept_func(true);
           this.show_advanced_errors = false;
+
+          // Reload the period data from Firebase
+          // This is easier than trying to update this.periods to match all the changes
+          await this.load_periods();
+
+          // This has to come after load_periods, to force the page to recompute its
+          // displayed values
+          this.changes = new Object();
         }
       });
 

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -335,8 +335,8 @@ export default {
       ],
 
       button_header_r: [
+        {name: 'Current', arr: 'h'},
         {name: 'Next', val: 'next'},
-        {name: 'Current', arr: 'd'},
         {name: 'Registration', arr: 'b', val: 'max'},
       ],
 

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -61,8 +61,6 @@
               &times;
             </b-button>
           </PeriodsClassesDisplay>
-
-          <ProfilePopup :ID="selected_youth.ID" />
         </div>
 
         <div v-else>
@@ -156,11 +154,17 @@
 
         </div>
 
+        <div style="padding: 1rem 0px; margin: auto;">
+        <ProfilePopup :ID="selected_youth.ID"
+          v-if="selected_youths.length == 1"
+          style="display:inline-block; margin: 0px 5px; padding: 0px 25px;"
+        />
         <ModalDRS
           showIfChanges :hideReset="true"
           :hasChanges="has_changes"
           @save="save_changes"
           @discard="discard_changes"
+          style="display:inline-block;"
         >
           <template slot="bodyFooter">
             <table class="table table-bordered">
@@ -230,6 +234,7 @@
               />
           </template>
         </ModalDRS>
+        </div>
 
       </div>
     </div>

--- a/blackstone-webapp/src/views/staff/ManagePeriods.vue
+++ b/blackstone-webapp/src/views/staff/ManagePeriods.vue
@@ -6,13 +6,12 @@
 
     <div class="col-container flex-direction">
       <div class="col-left">
-        <h3>{{display_period}}{{display_period == cur_period ? " (Current)" : display_period == reg_period ? " (Registration)" : ""}}</h3>
-
         <ButtonArrayHeader
-          :left ="button_header_l" :right="button_header_r" :current="display_period"
+          :left="button_header_l" :right="button_header_r" :current="display_period"
           :min="fst_period" :max="reg_period" :compareFunc="compare_periods"
           @clicked="switch_to"
         >
+          <h3>{{display_period}}{{display_period == cur_period ? " (Current)" : display_period == reg_period ? " (Registration)" : ""}}</h3>
         </ButtonArrayHeader>
         <Table
           ref="current_table"

--- a/blackstone-webapp/src/views/staff/ProfileLookupAndEditing.vue
+++ b/blackstone-webapp/src/views/staff/ProfileLookupAndEditing.vue
@@ -4,7 +4,7 @@
     <TopBar/>
 
     <h1 class="title">Profile Lookup and Editing</h1>
-    <YouthIDSelector @selected="load_youth"/>
+    <YouthIDSelector @selected="load_youth" :args="{openDirection: 'bottom'}" />
     <br />
 
     <div ref="body_fields" v-show="currentProfile != null">

--- a/blackstone-webapp/src/views/staff/ProfileLookupAndEditing.vue
+++ b/blackstone-webapp/src/views/staff/ProfileLookupAndEditing.vue
@@ -41,6 +41,7 @@
     </div>
 
     <div v-show="currentProfile == null">
+      <br>
       <p>Search the bar above to view a youth's profile information.</p>
     </div>
     </div>
@@ -196,7 +197,7 @@ export default {
 </script>
 
 <style>
-    .title {
+  .title {
     margin-bottom: 1rem;
-    }
+  }
 </style>

--- a/blackstone-webapp/src/views/staff/ProfileLookupAndEditing.vue
+++ b/blackstone-webapp/src/views/staff/ProfileLookupAndEditing.vue
@@ -8,7 +8,22 @@
     <br />
 
     <div ref="body_fields" v-show="currentProfile != null">
-      <ProfileFields :profile="currentProfile" :headerDoc="header_doc" :periodData="period_data" edit showOptionalFields />
+      <ProfileFields
+        :profile="currentProfile"
+        :headerDoc="header_doc"
+        edit showOptionalFields
+      />
+
+      <br /><br />
+
+      <h3>Active Periods & Classes</h3>
+      <PeriodsClassesDisplay
+        :active_periods="current_active_periods"
+        :seasons="period_metadata['seasons']"
+        v-bind="period_metadata"
+        disable_selection
+        style="max-width: 95%; margin:auto"
+      />
 
       <br />
 
@@ -39,13 +54,18 @@ import {db} from '../../firebase';
 import {firebase} from '../../firebase';
 import firebase_app from 'firebase/app';
 import firebase_auth from 'firebase/auth';
+
 import TopBar from '@/components/TopBar';
 import YouthIDSelector from "@/components/YouthIDSelector.vue"
 import ProfileFields from "@/components/ProfileFields.vue"
 import ApronBar from "@/components/ApronBar.vue"
 import ProfileItemLogs from "@/components/ProfileItemLogs.vue";
+import PeriodsClassesDisplay from "@/components/PeriodsClassesDisplay";
+
 import {Period} from "@/scripts/Period.js";
 import {mapKeyVal} from "@/scripts/ParseDB.js";
+import {mapObj} from "@/scripts/ParseDB.js";
+import {Youth} from "@/scripts/Youth.js";
 
 export default {
   name: 'profile_lookup_youth',
@@ -55,6 +75,7 @@ export default {
     ProfileFields,
     ApronBar,
     ProfileItemLogs,
+    PeriodsClassesDisplay,
   },
 
   data: function() {
@@ -65,8 +86,12 @@ export default {
 
       periods_db: db.collection("GlobalPeriods"),
       periods_doc: null,
-      period_data: null,
+      period_metadata: null,
       periods: [],
+
+      period_data: new Object(),
+
+      current_active_periods: new Object(),
     };
   },
 
@@ -79,13 +104,35 @@ export default {
     methods: {
 
       load_profile_data: async function() {
-        this.periods_doc = await this.periods_db.doc("metadata").get();
+
+        // Load the Periods collection and go through each document in it
+        var snapshot = await this.periods_db.get();
+        snapshot.docs.forEach(doc => {
+
+          // Handle based on document ID
+          switch (doc.id) {
+
+            // For the metadata document, load season data
+            case "metadata":
+              this.handle_period_metadata(doc);
+              break;
+
+            // For all year documents, load the data
+            default:
+              this.period_data[doc.id] = doc.data();
+              break;
+          }
+        });
+      },
+
+      handle_period_metadata: async function(doc) {
+        this.periods_doc = doc; // await this.periods_db.doc("metadata").get();
         var data = this.periods_doc.data();
 
         await Period.setSeasons(data["Seasons"]);
         this.periods = Period.enumerateStr(data["CurrentPeriod"], data["FirstPeriod"]);
 
-        this.period_data = {
+        this.period_metadata = {
           cur_period: data["CurrentPeriod"],
           reg_period: data["CurrentRegistrationPeriod"],
           seasons:    data["Seasons"],
@@ -105,8 +152,45 @@ export default {
         else {
           this.profile_snapshot = db.collection("GlobalYouthProfile").doc(youth.ID);
           this.currentProfile = await this.profile_snapshot.get();
+          this.current_active_periods = this.create_active_periods(youth, this.period_data);
         }
       },
+
+
+      create_active_periods: function(youth, period_data) {
+
+        // Collect all the seasons from the nested year -> season data structure
+        var obj = Object.entries(period_data).reduce( (acc, [_, seasons]) => {
+          return {...acc, ...seasons}
+        }, {} );
+
+        // Convert each period list into the youth's class during that period
+        // If youth not active, remove the period from the object
+        mapObj(obj, (period, val) => {
+
+          // Find all instances matching the youth in this period
+          let matches = Youth.findMatches(val, youth);
+
+          // If youth not active in this period, delete it from the object
+          if (matches.length == 0) {
+            return undefined;
+          }
+
+          // If youth found once, set the value to their class
+          else if (matches.length == 1) {
+            return {key: period, value: matches[0]["Class"]};
+          }
+
+          // If found more than once, flag it and use the first instance in the list
+          else {
+            console.warn("Multiple instances of youth " + youth + " in period " + period);
+            return {key: period, value: matches[0]["Class"]};
+          }
+        });
+
+        // Return the final object
+        return obj;
+      }
     }
 }
 </script>

--- a/blackstone-webapp/src/views/youth/ProfileLookup.vue
+++ b/blackstone-webapp/src/views/youth/ProfileLookup.vue
@@ -17,6 +17,7 @@ Profile Lookup is a restricted version of Profile Lookup & Editing, located in s
       <ProfileFields
         :profile="currentProfile"
         :headerDoc="header_doc"
+        :disableWarnings="true"
         showOptionalFields
       />
 

--- a/blackstone-webapp/src/views/youth/ProfileLookup.vue
+++ b/blackstone-webapp/src/views/youth/ProfileLookup.vue
@@ -8,7 +8,7 @@ Profile Lookup is a restricted version of Profile Lookup & Editing, located in s
     <top-bar/>
     <h1 class="title">Profile Lookup</h1>
     <br />
-    <YouthIDSelector @selected="load_youth"/>
+    <YouthIDSelector @selected="load_youth" :args="{openDirection: 'bottom'}" />
     <br />
 
     <!-- This has to be v-show, not v-if, so that the components are actually loaded -->

--- a/blackstone-webapp/src/views/youth/ProfileLookup.vue
+++ b/blackstone-webapp/src/views/youth/ProfileLookup.vue
@@ -17,8 +17,18 @@ Profile Lookup is a restricted version of Profile Lookup & Editing, located in s
       <ProfileFields
         :profile="currentProfile"
         :headerDoc="header_doc"
-        :periodData="period_data"
         showOptionalFields
+      />
+
+      <br /><br />
+
+      <h3>Active Periods & Classes</h3>
+      <PeriodsClassesDisplay
+        :active_periods="current_active_periods"
+        :seasons="period_metadata['seasons']"
+        v-bind="period_metadata"
+        disable_selection
+        style="max-width: 95%; margin:auto"
       />
 
       <!-- <br />
@@ -53,13 +63,18 @@ import {db} from '../../firebase';
 import {firebase} from '../../firebase';
 import firebase_app from 'firebase/app';
 import firebase_auth from 'firebase/auth';
+
 import TopBar from '@/components/TopBar';
 import YouthIDSelector from "@/components/YouthIDSelector.vue"
 import ProfileFields from "@/components/ProfileFields.vue"
 import ApronBar from "@/components/ApronBar.vue"
 import ProfileItemLogs from "@/components/ProfileItemLogs.vue";
+import PeriodsClassesDisplay from "@/components/PeriodsClassesDisplay";
+
 import {Period} from "@/scripts/Period.js";
 import {mapKeyVal} from "@/scripts/ParseDB.js";
+import {mapObj} from "@/scripts/ParseDB.js";
+import {Youth} from "@/scripts/Youth.js";
 
 export default {
   name: 'profile_lookup_youth',
@@ -69,6 +84,7 @@ export default {
     ProfileFields,
     ApronBar,
     ProfileItemLogs,
+    PeriodsClassesDisplay,
   },
 
   data: function() {
@@ -79,9 +95,12 @@ export default {
 
       periods_db: db.collection("GlobalPeriods"),
       periods_doc: null,
-      period_data: null,
+      period_metadata: null,
       periods: [],
 
+      period_data: new Object(),
+
+      current_active_periods: new Object(),
     };
   },
 
@@ -96,8 +115,28 @@ export default {
     // Load the period data for the children
     load_period_data: async function() {
 
-      // Get period doc & data from database
-      this.periods_doc = await this.periods_db.doc("metadata").get();
+      // Load the Periods collection and go through each document in it
+      var snapshot = await this.periods_db.get();
+      snapshot.docs.forEach(doc => {
+
+        // Handle based on document ID
+        switch (doc.id) {
+
+          // For the metadata document, load season data
+          case "metadata":
+            this.handle_period_metadata(doc);
+            break;
+
+          // For all year documents, load the data
+          default:
+            this.period_data[doc.id] = doc.data();
+            break;
+        }
+      });
+    },
+
+    handle_period_metadata: async function(doc) {
+      this.periods_doc = doc; // await this.periods_db.doc("metadata").get();
       var data = this.periods_doc.data();
 
       // Set the seasons for the Period object
@@ -107,7 +146,7 @@ export default {
       this.periods = Period.enumerateStr(data["CurrentPeriod"], data["FirstPeriod"]);
 
       // Summarize period data to pass to children
-      this.period_data = {
+      this.period_metadata = {
         cur_period: data["CurrentPeriod"],
         reg_period: data["CurrentRegistrationPeriod"],
         seasons:    data["Seasons"],
@@ -128,8 +167,44 @@ export default {
       else {
         this.profile_snapshot = db.collection("GlobalYouthProfile").doc(youth.ID);
         this.currentProfile = await this.profile_snapshot.get();
+        this.current_active_periods = this.create_active_periods(youth, this.period_data);
       }
     },
+
+    create_active_periods: function(youth, period_data) {
+
+      // Collect all the seasons from the nested year -> season data structure
+      var obj = Object.entries(period_data).reduce( (acc, [_, seasons]) => {
+        return {...acc, ...seasons}
+      }, {} );
+
+      // Convert each period list into the youth's class during that period
+      // If youth not active, remove the period from the object
+      mapObj(obj, (period, val) => {
+
+        // Find all instances matching the youth in this period
+        let matches = Youth.findMatches(val, youth);
+
+        // If youth not active in this period, delete it from the object
+        if (matches.length == 0) {
+          return undefined;
+        }
+
+        // If youth found once, set the value to their class
+        else if (matches.length == 1) {
+          return {key: period, value: matches[0]["Class"]};
+        }
+
+        // If found more than once, flag it and use the first instance in the list
+        else {
+          console.warn("Multiple instances of youth " + youth + " in period " + period);
+          return {key: period, value: matches[0]["Class"]};
+        }
+      });
+
+      // Return the final object
+      return obj;
+    }
   }
 }
 </script>


### PR DESCRIPTION
Update Production to match recent work in Vue branch, mostly to do with `ManagePeriods` and other period/class pieces.

**Major/Relevant Updates**
- Both `ManagePeriods` and Youth Profile pages now read youth period/class data from `GlobalPeriods`, meaning the youth's `ActivePeriods` field is now obsolete.
- Moved Profile popup modal to its own component, which can be used on any page as long as the ID is given.  If you already have header/profile information loaded, it's possible to pass it in through props (to cut down on reads & for customizability), but it can also retrieve that on its own if none is given.
- `AwaitTransactions` object in `ParseDB.js` will take a series of Firebase transactions, perform them all, and run a given success/failure callback after all transactions come back. Makes it easier to manage/synchronize updates to multiple locations in the database.
- Use `ModalDRS` component to handle edits (Discard, Reset, and Save buttons linked to a series of popup modals).

**Miscellaneous Updates**
- Item logs in profile pages should now initially sort by date (originally sorted by document ID on Firebase)
- Hour display divs on profile page now have their own component
- New `mapObj` function in `ParseDB.js`
- Warning badges on youth fields only display in staff view, and can be (de)activated with a prop